### PR TITLE
LPS-33176

### DIFF
--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -303,7 +303,7 @@ if (Validator.isNull(mainLanguageValue)) {
 
 		if (languageSelectorTrigger) {
 			Liferay.component(
-				'<%= namespace + name %>languageSelector',
+				'<%= randomNamespace %>languageSelector',
 				function(event) {
 					if (handle) {
 						handle.detach();
@@ -329,7 +329,7 @@ if (Validator.isNull(mainLanguageValue)) {
 			var handle = languageSelectorTrigger.once(
 				'click',
 				function(event) {
-					Liferay.component('<%= namespace + name %>languageSelector');
+					Liferay.component('<%= randomNamespace %>languageSelector');
 				}
 			);
 		}


### PR DESCRIPTION
Hi Zsiga,

This is a small fix which makes the use of generated IDs consistent.

In portal-web/docroot/html/taglib/ui/input_localized/page.jsp the following pattern is being used: <%= randomNamespace %>languageSelector*; however there were two exceptions.

The regression is coming from 46ce3cf3fa52332c3b8be5bb1c989966419cf1bf, where <%= namespace + name %> was introduced as a namespace prefix.

Cheers,
Laci.
