### PR TITLE
[TECHNICAL SUPPORT] LPS-33357 Made LookAndFeel div id unique to fix regression bug

### DIFF
--- a/portal-web/docroot/html/portlet/layouts_admin/look_and_feel_themes.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/look_and_feel_themes.jsp
@@ -31,7 +31,7 @@ Map<String, ThemeSetting> configurableSettings = selTheme.getConfigurableSetting
 %>
 
 <div class="lfr-theme-list">
-	<div class="float-container lfr-current-theme" id="<%= device %>LookAndFeel">
+	<div class="float-container lfr-current-theme" id="<%= editable ? device : StringPool.BLANK %>LookAndFeel">
 		<h3><liferay-ui:message key="current-theme" /></h3>
 
 		<div>


### PR DESCRIPTION
Hi Zsigmond,

This issue fixes the regression bug caused my previous commit in LPS-32581. The problem is that the div with <%= device %>LookAndFeel id is not unique and the the form that is conatined by this div contains inputs only when the form is editable, that caused JavaScript error at rendering.

Regards,
Vilmos
