### PR TITLE
[TECHNICAL SUPPORT] LPS-33862 Escaped URL attribute to avoid XSS execution

### DIFF
--- a/portal-web/docroot/html/taglib/ui/captcha/simplecaptcha.jsp
+++ b/portal-web/docroot/html/taglib/ui/captcha/simplecaptcha.jsp
@@ -36,7 +36,7 @@ catch (CaptchaMaxChallengesException cmce) {
 
 <c:if test="<%= captchaEnabled %>">
 	<div class="taglib-captcha">
-		<img alt="<liferay-ui:message key="text-to-identify" />" class="captcha" src="<%= url %>" />
+		<img alt="<liferay-ui:message key="text-to-identify" />" class="captcha" src="<%= HtmlUtil.escapeAttribute(url) %>" />
 
 		<aui:input label="text-verification" name="captchaText" size="10" type="text" value="">
 			<aui:validator name="required" />


### PR DESCRIPTION
Hi Zsigmond,

In this issue I simply escape the attribute of an image src as parameters with XSS load could be appended to it.

Regards,
Vilmos
