### PR TITLE
[TECHNICAL SUPPORT] LPS-34816 Made Application Adapter working consistent when staging is turned on.

### DIFF
--- a/portal-web/docroot/html/portlet/sites_admin/site/details.jsp
+++ b/portal-web/docroot/html/portlet/sites_admin/site/details.jsp
@@ -330,8 +330,8 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 					<%
 					String customJspServletContextName = StringPool.BLANK;
 
-					if (group != null) {
-						UnicodeProperties typeSettingsProperties = group.getTypeSettingsProperties();
+					if (liveGroup != null) {
+						UnicodeProperties typeSettingsProperties = liveGroup.getTypeSettingsProperties();
 
 						customJspServletContextName = GetterUtil.getString(typeSettingsProperties.get("customJspServletContextName"));
 					}

--- a/util-taglib/src/com/liferay/taglib/util/IncludeTag.java
+++ b/util-taglib/src/com/liferay/taglib/util/IncludeTag.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.servlet.DirectRequestDispatcherFactoryUtil;
 import com.liferay.portal.kernel.servlet.PipingServletResponse;
 import com.liferay.portal.kernel.servlet.TrackedServletRequest;
 import com.liferay.portal.kernel.servlet.taglib.FileAvailabilityUtil;
+import com.liferay.portal.kernel.staging.StagingUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -234,7 +235,13 @@ public class IncludeTag extends AttributesTagSupport {
 			return null;
 		}
 
-		Group group = themeDisplay.getScopeGroup();
+		Group group;
+
+		try {
+			group = StagingUtil.getLiveGroup(themeDisplay.getScopeGroupId());
+		} catch (Exception e) {
+			return null;
+		}
 
 		UnicodeProperties typeSettingsProperties =
 			group.getTypeSettingsProperties();


### PR DESCRIPTION
Hi Zsigmond,

This issue is related to the typeSettings saving into liveGroup only we've discussed. I've checked the code and the relevant code part in IncludeTag strictly relates to the Application Adapter Hook feature, so I made the logic consistent on the Site editing panel and the in the IncludeTag so we have the same working when staging is turned on or off now.

Regards,
Vilmos
