### PR TITLE
[TECHNICAL SUPPORT] LPS-34846 Fixed groupId and type extraction logic when article is found

### DIFF
--- a/portal-web/docroot/html/portlet/journal_content/configuration.jsp
+++ b/portal-web/docroot/html/portlet/journal_content/configuration.jsp
@@ -38,8 +38,10 @@ try {
 catch (NoSuchArticleException nsae) {
 }
 
-groupId = ParamUtil.getLong(request, "groupId", themeDisplay.getScopeGroupId());
-type = ParamUtil.getString(request, "type", type);
+if (article == null) {
+	groupId = ParamUtil.getLong(request, "groupId", themeDisplay.getScopeGroupId());
+	type = ParamUtil.getString(request, "type", type);
+}
 %>
 
 <liferay-portlet:actionURL portletConfiguration="true" var="configurationActionURL" />


### PR DESCRIPTION
Hi Zsigmond,

There was a bug in the logic we extracted groupId and type variables in the configuration of Web Content Display. This caused inconsistent working when the originally selected article was selected from the Global scope. The problem was that we always overrode the groupId with the request's groupId or the themeDisplay.getScopeGroupId() even though we successfully loaded it from the prefenreces and/or from the article.getGroupId().

Regards,
Vilmos
