### PR TITLE
LPS-32657 Force select vocabulary because of Firefox behavior

### DIFF
--- a/portal-web/docroot/html/portlet/asset_category_admin/js/main.js
+++ b/portal-web/docroot/html/portlet/asset_category_admin/js/main.js
@@ -1800,6 +1800,7 @@ AUI.add(
 
 							if (selectNode) {
 								selectedVocabularyId = toInt(selectedVocabularyId);
+								var selectedVocabularyIndex;
 
 								selectNode.empty();
 
@@ -1812,6 +1813,8 @@ AUI.add(
 
 										if (item.vocabularyId == selectedVocabularyId) {
 											item[STR_SELECTED] = STR_SELECTED;
+
+											selectedVocabularyIndex = index;
 										}
 
 										buffer.push(
@@ -1828,6 +1831,8 @@ AUI.add(
 								);
 
 								selectNode.append(buffer.join(STR_EMPTY));
+
+								selectNode._node.selectedIndex = selectedVocabularyIndex;
 							}
 						}
 					},


### PR DESCRIPTION
[TECHNICAL-SUPPORT] [LPS-32657] In "Add Category" window the value of "To Vocabulary" field is the last vocabulary on the list instead of currently selected one
