### PR TITLE
LPS-37812 Added NormalizedHeaderName based CSS classes

### DIFF
--- a/portal-web/docroot/html/taglib/ui/search_iterator/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/page.jsp
@@ -140,7 +140,7 @@ int sortColumnIndex = -1;
 					}
 				%>
 
-					<th class="<%= cssClass %>" id="<%= namespace + id %>_col-<%= normalizedHeaderName %>"
+					<th class="<%= cssClass %> col-<%= normalizedHeaderName %>" id="<%= namespace + id %>_col-<%= normalizedHeaderName %>"
 
 						<%--
 
@@ -299,7 +299,7 @@ int sortColumnIndex = -1;
 				}
 			%>
 
-				<td class="table-cell <%= columnClassName %>">
+				<td class="table-cell col-<%= normalizedHeaderName %> <%= columnClassName %>">
 
 					<%
 					entry.print(pageContext);


### PR DESCRIPTION
Hi Zsigmond,

This fix adds back the missing CSS classes that are used for JS event handling in publish_layouts_select_pages.jspf

Regards,
Vilmos
