### PR TITLE
[TECHNICAL SUPPORT] LPS-38255 Added redirect param to URLs so the public render parameters are kept with category filtering settings

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
@@ -295,6 +295,7 @@ public class AssetUtil {
 
 			redirectURL.setParameter(
 				"struts_action", "/asset_publisher/add_asset_redirect");
+			redirectURL.setParameter("redirect", themeDisplay.getURLCurrent());
 			redirectURL.setWindowState(LiferayWindowState.POP_UP);
 
 			redirect = redirectURL.toString();

--- a/portal-web/docroot/html/portlet/asset_publisher/asset_actions.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/asset_actions.jsp
@@ -35,6 +35,9 @@ if (showEditURL && assetRenderer.hasEditPermission(permissionChecker)) {
 	if (fullContentRedirect != null) {
 		redirectURL.setParameter("redirect", fullContentRedirect);
 	}
+	else {
+		redirectURL.setParameter("redirect", currentURL);
+	}
 
 	redirectURL.setWindowState(LiferayWindowState.POP_UP);
 


### PR DESCRIPTION
Hi Zsigmond,

This is the CategoryId selection vs. Asset Publisher problem we discussed.

Regards,
Vilmos
