### PR TITLE
LPS-38468 Not sitemapable layout's children won't be included in sitemap.xml

### DIFF
--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/util/SitemapImpl.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/util/SitemapImpl.java
@@ -278,46 +278,45 @@ public class SitemapImpl implements Sitemap {
 		UnicodeProperties typeSettingsProperties =
 			layout.getTypeSettingsProperties();
 
-		if (layout.isHidden() || !PortalUtil.isLayoutSitemapable(layout) ||
-			!GetterUtil.getBoolean(
+		if (!layout.isHidden() && PortalUtil.isLayoutSitemapable(layout) &&
+			GetterUtil.getBoolean(
 				typeSettingsProperties.getProperty("sitemap-include"), true)) {
 
-			return;
-		}
+			String layoutFullURL = PortalUtil.getLayoutFullURL(
+				layout, themeDisplay);
 
-		String layoutFullURL = PortalUtil.getLayoutFullURL(
-			layout, themeDisplay);
+			layoutFullURL = PortalUtil.getCanonicalURL(
+				layoutFullURL, themeDisplay, layout);
 
-		layoutFullURL = PortalUtil.getCanonicalURL(
-			layoutFullURL, themeDisplay, layout);
+			addURLElement(
+				element, layoutFullURL, typeSettingsProperties,
+				layout.getModifiedDate(), layoutFullURL,
+				getAlternateURLs(layoutFullURL, themeDisplay, layout));
 
-		addURLElement(
-			element, layoutFullURL, typeSettingsProperties,
-			layout.getModifiedDate(), layoutFullURL,
-			getAlternateURLs(layoutFullURL, themeDisplay, layout));
+			Locale[] availableLocales = LanguageUtil.getAvailableLocales(
+				layout.getGroupId());
 
-		Locale[] availableLocales = LanguageUtil.getAvailableLocales(
-			layout.getGroupId());
+			if (availableLocales.length > 1) {
+				Locale defaultLocale = LocaleUtil.getSiteDefault();
 
-		if (availableLocales.length > 1) {
-			Locale defaultLocale = LocaleUtil.getSiteDefault();
+				for (Locale availableLocale : availableLocales) {
+					if (availableLocale.equals(defaultLocale)) {
+						continue;
+					}
 
-			for (Locale availableLocale : availableLocales) {
-				if (availableLocale.equals(defaultLocale)) {
-					continue;
+					String alternateURL = PortalUtil.getAlternateURL(
+						layoutFullURL, themeDisplay, availableLocale, layout);
+
+					addURLElement(
+						element, alternateURL, typeSettingsProperties,
+						layout.getModifiedDate(), layoutFullURL,
+						getAlternateURLs(layoutFullURL, themeDisplay, layout));
 				}
-
-				String alternateURL = PortalUtil.getAlternateURL(
-					layoutFullURL, themeDisplay, availableLocale, layout);
-
-				addURLElement(
-					element, alternateURL, typeSettingsProperties,
-					layout.getModifiedDate(), layoutFullURL,
-					getAlternateURLs(layoutFullURL, themeDisplay, layout));
 			}
+
+			visitArticles(element, layout, themeDisplay);
 		}
 
-		visitArticles(element, layout, themeDisplay);
 		visitLayouts(element, layout.getChildren(), themeDisplay);
 	}
 


### PR DESCRIPTION
[TECHNICAL SUPPORT] LPS-38468 Not sitemapable layout's children won't be included in sitemap.xml

Hi Zsigmond,

As per our conversation with Tamás I'm sending this PR to trunk. I could test it correctly only on 6.1.x, however the code is almost the same and should work properly here, as well.
On trunk the manage site pages feature is not working: I couldn't hide a layout or in SEO/robots couldn't set the include to false. Link to page didn't work either, the select field was empty.
The only I could do when testing on trunk was manually modifying the layout table and set the layout to hidden and test this way - it worked correctly.

Thank you,
Gábor
