### PR TITLE
[Story | Quick_win] LPS-38484 Do not show empty "Display Date" column in view "View History" when you are editing default values of a Structure

### DIFF
--- a/portal-web/docroot/html/portlet/journal/view_article_history.jsp
+++ b/portal-web/docroot/html/portlet/journal/view_article_history.jsp
@@ -68,6 +68,12 @@ JournalArticle article = (JournalArticle)request.getAttribute(WebKeys.JOURNAL_AR
 
 			orderableHeaders.put("version", "version");
 
+			if (article.getClassNameId() > JournalArticleConstants.CLASSNAME_ID_DEFAULT) {
+				headerNames.remove("display-date");
+
+				orderableHeaders.remove("display-date");
+			}
+
 			if (Validator.isNull(orderByCol)) {
 				searchContainer.setOrderByCol("version");
 			}
@@ -134,7 +140,9 @@ JournalArticle article = (JournalArticle)request.getAttribute(WebKeys.JOURNAL_AR
 
 				// Display date
 
-				row.addDate(articleVersion.getDisplayDate(), rowURL);
+				if (articleVersion.getClassNameId() == JournalArticleConstants.CLASSNAME_ID_DEFAULT) {
+					row.addDate(articleVersion.getDisplayDate(), rowURL);
+				}
 
 				// Author
 


### PR DESCRIPTION
Hi Zsigmond,

I have created http://issues.liferay.com/browse/LPS-38484 to keep 6.2.x and ee-6.1.x in sync. http://issues.liferay.com/browse/LPS-38481 fixes a regression bug on the latter branch.

=== Full commit message
1. Current behavior
   Since LPS-30512, we don't save the displayDate for a Web Content that stores the default values of a structure. Therefore, the Display Date column will always be empty in the view View History when your are editing this default content.
2. Expected behavior
   Display this column only for "real" Web Contents.
3. About the changes
   It is safe to remove an element from list "headerNames" and from map "orderableHeaders", as they are instance-scoped variables of a SearchContainer object:

private List<String> _headerNames;
private Map<String, String> _orderableHeaders;

The static initializations in the ArticleSearch class ensure that the newly created container instances will have the same initial names, but when we call #add, #clear or #remove the in views, these actions change the instance variables, not the static ones.

Removing "display-date" elements in certain case (viewing history of a default article content) seems more reasonable than clearing the whole list/map and refill it with the same values this one.
