### PR TITLE
[TECHNICAL SUPPORT] LPS-38618 Handle SESSION_COOKIE_USE_FULL_HOSTNAME in all places where Cookie domain comes in picture

### DIFF
--- a/portal-impl/src/com/liferay/portal/action/LogoutAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LogoutAction.java
@@ -53,7 +53,11 @@ public class LogoutAction extends Action {
 				PropsKeys.LOGOUT_EVENTS_PRE, PropsValues.LOGOUT_EVENTS_PRE,
 				request, response);
 
-			String domain = CookieKeys.getDomain(request);
+			String domain = StringPool.BLANK;
+
+			if (!PropsValues.SESSION_COOKIE_USE_FULL_HOSTNAME) {
+				domain = CookieKeys.getDomain(request);
+			}
 
 			Cookie companyIdCookie = new Cookie(
 				CookieKeys.COMPANY_ID, StringPool.BLANK);

--- a/portal-impl/src/com/liferay/portal/events/SiteMinderLogoutAction.java
+++ b/portal-impl/src/com/liferay/portal/events/SiteMinderLogoutAction.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.auth.AuthSettingsUtil;
 import com.liferay.portal.util.PortalUtil;
+import com.liferay.portal.util.PropsValues;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -41,7 +42,11 @@ public class SiteMinderLogoutAction extends Action {
 				return;
 			}
 
-			String domain = CookieKeys.getDomain(request);
+			String domain = StringPool.BLANK;
+
+			if (!PropsValues.SESSION_COOKIE_USE_FULL_HOSTNAME) {
+				domain = CookieKeys.getDomain(request);
+			}
 
 			Cookie smSessionCookie = new Cookie(_SMSESSION, StringPool.BLANK);
 

--- a/portal-impl/src/com/liferay/portal/util/HttpImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HttpImpl.java
@@ -1191,7 +1191,11 @@ public class HttpImpl implements Http {
 		Cookie cookie = new Cookie(
 			commonsCookie.getName(), commonsCookie.getValue());
 
-		String domain = commonsCookie.getDomain();
+		String domain = StringPool.BLANK;
+
+		if (!PropsValues.SESSION_COOKIE_USE_FULL_HOSTNAME) {
+			domain = commonsCookie.getDomain();
+		}
 
 		if (Validator.isNotNull(domain)) {
 			cookie.setDomain(domain);

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1630,6 +1630,8 @@ public class PropsValues {
 
 	public static final String SESSION_COOKIE_DOMAIN = PropsUtil.get(PropsKeys.SESSION_COOKIE_DOMAIN);
 
+	public static final boolean SESSION_COOKIE_USE_FULL_HOSTNAME = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.SESSION_COOKIE_USE_FULL_HOSTNAME));
+
 	public static final boolean SESSION_DISABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.SESSION_DISABLED));
 
 	public static final boolean SESSION_ENABLE_PERSISTENT_COOKIES = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.SESSION_ENABLE_PERSISTENT_COOKIES));

--- a/portal-impl/src/com/liferay/portlet/login/util/LoginUtil.java
+++ b/portal-impl/src/com/liferay/portlet/login/util/LoginUtil.java
@@ -304,7 +304,11 @@ public class LoginUtil {
 
 		// Set cookies
 
-		String domain = CookieKeys.getDomain(request);
+		String domain = StringPool.BLANK;
+
+		if (!PropsValues.SESSION_COOKIE_USE_FULL_HOSTNAME) {
+			domain = CookieKeys.getDomain(request);
+		}
 
 		User user = UserLocalServiceUtil.getUserById(userId);
 

--- a/portal-service/src/com/liferay/portal/kernel/util/CookieKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/CookieKeys.java
@@ -17,6 +17,7 @@ package com.liferay.portal.kernel.util;
 import com.liferay.portal.CookieNotSupportedException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.util.PropsValues;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -153,7 +154,7 @@ public class CookieKeys {
 
 		String host = request.getServerName();
 
-		if (_SESSION_COOKIE_USE_FULL_HOSTNAME) {
+		if (PropsValues.SESSION_COOKIE_USE_FULL_HOSTNAME) {
 			return host;
 		}
 
@@ -290,10 +291,6 @@ public class CookieKeys {
 
 	private static final String _SESSION_COOKIE_DOMAIN = PropsUtil.get(
 		PropsKeys.SESSION_COOKIE_DOMAIN);
-
-	private static final boolean _SESSION_COOKIE_USE_FULL_HOSTNAME =
-		GetterUtil.getBoolean(
-			PropsUtil.get(PropsKeys.SESSION_COOKIE_USE_FULL_HOSTNAME));
 
 	private static final boolean _SESSION_ENABLE_PERSISTENT_COOKIES =
 		GetterUtil.getBoolean(


### PR DESCRIPTION
Hi Zsigmond,

This issue makes the session.cookie.use.full.hostname settings applicable by not explicitly set the domain for some cookies. If someone enables the above setting, from now he can be sure that each cookie will have the hostname as the domain of the cookie instead of having a leading dot before the hostname.

Regards,
Vilmos
