### PR TITLE
[TECHNICAL REQUEST] LPS-58336 After setting context path in tomcat portal UI is unusable

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
@@ -111,6 +111,15 @@ public class ComboServlet extends HttpServlet {
 	}
 
 	protected static String getResourcePath(String modulePath) {
+		return getResourcePath(modulePath, PortalUtil.getPathContext());
+	}
+
+	protected static String getResourcePath(
+		String modulePath, String pathContext) {
+
+		modulePath = StringUtil.replaceFirst(
+			modulePath, pathContext, StringPool.BLANK);
+
 		int index = modulePath.indexOf(CharPool.COLON);
 
 		if (index > 0) {
@@ -378,7 +387,8 @@ public class ComboServlet extends HttpServlet {
 
 		ServletContext servletContext = portletApp.getServletContext();
 
-		String resourcePath = getResourcePath(modulePath);
+		String resourcePath = getResourcePath(
+			modulePath, servletContext.getContextPath());
 
 		if (!PortalUtil.isValidResourceId(resourcePath)) {
 			if (_log.isWarnEnabled()) {

--- a/portal-impl/test/unit/com/liferay/portal/servlet/ComboServletTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/servlet/ComboServletTest.java
@@ -120,7 +120,7 @@ public class ComboServletTest extends PowerMockito {
 		ServletConfig servletConfig = new MockServletConfig(
 			_portalServletContext);
 
-		_portalServletContext.setContextPath("portal");
+		_portalServletContext.setContextPath(_CONTEXT);
 
 		when(
 			_portalPortletApp.getServletContext()
@@ -193,27 +193,24 @@ public class ComboServletTest extends PowerMockito {
 	public void testGetResourceRequestDispatcherWithoutPortletId()
 		throws Exception {
 
-		String path = "/js/javascript.js";
-
 		_comboServlet.getResourceRequestDispatcher(
-			_mockHttpServletRequest, _mockHttpServletResponse,
-			"/js/javascript.js");
+			_mockHttpServletRequest, _mockHttpServletResponse, _PATH);
 
-		verify(_portalServletContext);
-
-		_portalServletContext.getRequestDispatcher(path);
+		verify(_portalServletContext).getRequestDispatcher(_PATH);
 	}
 
 	@Test
 	public void testGetResourceWithPortletId() throws Exception {
 		_comboServlet.getResourceRequestDispatcher(
 			_mockHttpServletRequest, _mockHttpServletResponse,
-			PortletKeys.ADMIN + ":/js/javascript.js");
+			PortletKeys.ADMIN + ":" + _PATH);
 
-		verify(_pluginServletContext);
-
-		_pluginServletContext.getRequestDispatcher("/js/javascript.js");
+		verify(_pluginServletContext).getRequestDispatcher(_PATH);
 	}
+
+	private static final String _CONTEXT = "portal";
+
+	private static final String _PATH = "/js/javascript.js";
 
 	private static Portal _portal;
 	private static final PortalUtil _portalUtil = new PortalUtil();

--- a/portal-impl/test/unit/com/liferay/portal/servlet/ComboServletTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/servlet/ComboServletTest.java
@@ -200,6 +200,28 @@ public class ComboServletTest extends PowerMockito {
 	}
 
 	@Test
+	public void testGetResourceRequestDispatcherWithoutPortletIdButContext()
+		throws Exception {
+
+		_comboServlet.getResourceRequestDispatcher(
+			_mockHttpServletRequest, _mockHttpServletResponse,
+			_CONTEXT + _PATH);
+
+		verify(_portalServletContext).getRequestDispatcher(_PATH);
+	}
+
+	@Test
+	public void testGetResourceRequestDispatcherWithPortletIdAndContext()
+		throws Exception {
+
+		_comboServlet.getResourceRequestDispatcher(
+			_mockHttpServletRequest, _mockHttpServletResponse,
+			PortletKeys.PORTAL + ":" + _CONTEXT + _PATH);
+
+		verify(_portalServletContext).getRequestDispatcher(_PATH);
+	}
+
+	@Test
 	public void testGetResourceWithPortletId() throws Exception {
 		_comboServlet.getResourceRequestDispatcher(
 			_mockHttpServletRequest, _mockHttpServletResponse,

--- a/portal-impl/test/unit/com/liferay/portal/servlet/ModulePathContainerTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/servlet/ModulePathContainerTest.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.servlet;
 
 import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.tools.ToolDependencies;
 import com.liferay.portal.util.PortletKeys;
 
@@ -31,6 +32,15 @@ public class ModulePathContainerTest {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		ToolDependencies.wireCaches();
+	}
+
+	@Test
+	public void testModulePathWithContextPath() {
+		String modulePath = _CONTEXT + _PATH;
+		Assert.assertEquals(
+			PortletKeys.PORTAL, ComboServlet.getModulePortletId(modulePath));
+		Assert.assertEquals(
+			_PATH, ComboServlet.getResourcePath(modulePath, _CONTEXT));
 	}
 
 	@Test
@@ -52,6 +62,16 @@ public class ModulePathContainerTest {
 	}
 
 	@Test
+	public void testModulePathWithPortletIdAndContext() {
+		String modulePath = PortletKeys.PORTAL + ":" + _CONTEXT + _PATH;
+
+		Assert.assertEquals(
+			PortletKeys.PORTAL, ComboServlet.getModulePortletId(modulePath));
+		Assert.assertEquals(
+			_PATH, ComboServlet.getResourcePath(modulePath, _CONTEXT));
+	}
+
+	@Test
 	public void testModulePathWithPortletIdAndNoResourcePath() {
 		String modulePath = PortletKeys.PORTAL + ":";
 
@@ -61,6 +81,19 @@ public class ModulePathContainerTest {
 			StringPool.BLANK,
 			ComboServlet.getResourcePath(modulePath, StringPool.BLANK));
 	}
+
+	@Test
+	public void testModulePathWithPortletIdAndNoResourcePathButContext() {
+		String modulePath = PortletKeys.PORTAL + ":" + _CONTEXT;
+
+		Assert.assertEquals(
+			PortletKeys.PORTAL, ComboServlet.getModulePortletId(modulePath));
+		Assert.assertEquals(
+			StringPool.BLANK,
+			ComboServlet.getResourcePath(modulePath, _CONTEXT));
+	}
+
+	private static final String _CONTEXT = "/" + StringUtil.randomString();
 
 	private static final String _PATH = "/js/javascript.js";
 

--- a/portal-impl/test/unit/com/liferay/portal/servlet/ModulePathContainerTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/servlet/ModulePathContainerTest.java
@@ -35,22 +35,20 @@ public class ModulePathContainerTest {
 
 	@Test
 	public void testModulePathWithNoContextPath() {
-		String modulePath = "/js/javascript.js";
-
 		Assert.assertEquals(
-			PortletKeys.PORTAL, ComboServlet.getModulePortletId(modulePath));
+			PortletKeys.PORTAL, ComboServlet.getModulePortletId(_PATH));
 		Assert.assertEquals(
-			"/js/javascript.js", ComboServlet.getResourcePath(modulePath));
+			_PATH, ComboServlet.getResourcePath(_PATH, StringPool.BLANK));
 	}
 
 	@Test
 	public void testModulePathWithPortletId() {
-		String modulePath = PortletKeys.PORTAL + ":/js/javascript.js";
+		String modulePath = PortletKeys.PORTAL + ":" + _PATH;
 
 		Assert.assertEquals(
 			PortletKeys.PORTAL, ComboServlet.getModulePortletId(modulePath));
 		Assert.assertEquals(
-			"/js/javascript.js", ComboServlet.getResourcePath(modulePath));
+			_PATH, ComboServlet.getResourcePath(modulePath, StringPool.BLANK));
 	}
 
 	@Test
@@ -60,7 +58,10 @@ public class ModulePathContainerTest {
 		Assert.assertEquals(
 			PortletKeys.PORTAL, ComboServlet.getModulePortletId(modulePath));
 		Assert.assertEquals(
-			StringPool.BLANK, ComboServlet.getResourcePath(modulePath));
+			StringPool.BLANK,
+			ComboServlet.getResourcePath(modulePath, StringPool.BLANK));
 	}
+
+	private static final String _PATH = "/js/javascript.js";
 
 }


### PR DESCRIPTION
Hi,

I would like you to review this pull request.

I wanted to test a scenario on master with context and it turned out that master did not work if context is set. I did not want to bother Zsaga with this, because this is not a UI issue.

If you have no time to review this, just close it.

I got the idea of using PortalUtil.getPathContext() from a commit: 36e68331642278807ffbdb143b01a5a5b5e01e0a

The end of the request url contains paths separated with &. Based on these are the modulePath-s created. I also checked baseURL variable which is used to change relative urls in css files, (see in ComboServlet.java), it works well.

Thank you in advance
Péter