### PR TITLE
[TECHNICAL SUPPORT] LPS-59732 Change in the Look&Feel in a portlet of a Page Template wil…

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/META-INF/resources/layout/details.jsp
+++ b/modules/apps/layout/layout-admin-web/src/META-INF/resources/layout/details.jsp
@@ -134,6 +134,10 @@ StringBuilder friendlyURLBase = new StringBuilder();
 
 		<aui:input name="layoutPrototypeUuid" type="hidden" value="<%= selLayout.getLayoutPrototypeUuid() %>" />
 
+		<div class='portlet-msg-info <%= selLayout.isLayoutPrototypeLinkEnabled() ? "" : "hide" %>' id="<portlet:namespace/>layoutPrototypeInfoMessage">
+			<liferay-ui:message key="this-page-is-linked-to-a-page-template" />
+		</div>
+
 		<aui:input label='<%= LanguageUtil.format(request, "automatically-apply-changes-done-to-the-page-template-x", HtmlUtil.escape(layoutPrototype.getName(user.getLocale())), false) %>' name="layoutPrototypeLinkEnabled" type="checkbox" value="<%= selLayout.isLayoutPrototypeLinkEnabled() %>" />
 
 		<div class='<%= selLayout.isLayoutPrototypeLinkEnabled() ? "" : "hide" %>' id="<portlet:namespace/>layoutPrototypeMergeAlert">
@@ -210,6 +214,7 @@ StringBuilder friendlyURLBase = new StringBuilder();
 </aui:fieldset>
 
 <aui:script>
+	Liferay.Util.toggleBoxes('<portlet:namespace />layoutPrototypeLinkEnabled', '<portlet:namespace />layoutPrototypeInfoMessage');
 	Liferay.Util.toggleBoxes('<portlet:namespace />layoutPrototypeLinkEnabled', '<portlet:namespace />layoutPrototypeMergeAlert');
 	Liferay.Util.toggleBoxes('<portlet:namespace />layoutPrototypeLinkEnabled', '<portlet:namespace />typeOptions', true);
 </aui:script>


### PR DESCRIPTION
…l blank out JavaScript and Query String field of a page created from that template

Hi Zsigmond,

Please review my given solution for LPS-59732.

Based our discussion edit layout page displays an info message to users which indicates that current page is linked to a page template.

Thanks,
 Zsaga 