### PR TITLE
LPS-60205 MediaWiki import logic

### DIFF
--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/importer/impl/mediawiki/MediaWikiImporter.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/importer/impl/mediawiki/MediaWikiImporter.java
@@ -199,6 +199,12 @@ public class MediaWikiImporter implements WikiImporter {
 
 					content = _translator.translate(content);
 				}
+				else {
+					content = content.replaceAll(
+						_imagesPattern.pattern(),
+						"$1$2" + SHARED_IMAGES_TITLE + StringPool.SLASH +
+						"$3$4");
+				}
 			}
 			else {
 				content =
@@ -716,6 +722,8 @@ public class MediaWikiImporter implements WikiImporter {
 
 	private static final Pattern _categoriesPattern = Pattern.compile(
 		"\\[\\[[Cc]ategory:([^\\]]*)\\]\\][\\n]*");
+	private static final Pattern _imagesPattern = Pattern.compile(
+		"(\\[\\[Image|File)(:)([^\\]]*)(\\]\\])", Pattern.DOTALL);
 	private static final Pattern _parentPattern = Pattern.compile(
 		"\\{{2}OtherTopics\\|([^\\}]*)\\}{2}");
 	private static final Pattern _redirectPattern = Pattern.compile(

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/importer/impl/mediawiki/MediaWikiImporter.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/importer/impl/mediawiki/MediaWikiImporter.java
@@ -191,9 +191,14 @@ public class MediaWikiImporter implements WikiImporter {
 				readAssetTagNames(userId, node, content));
 
 			if (Validator.isNull(redirectTitle)) {
-				_translator.setStrictImportMode(strictImportMode);
+				if (Validator.equals(
+						_wikiGroupServiceConfiguration.defaultFormat(),
+						"creole")) {
 
-				content = _translator.translate(content);
+					_translator.setStrictImportMode(strictImportMode);
+
+					content = _translator.translate(content);
+				}
 			}
 			else {
 				content =
@@ -214,8 +219,9 @@ public class MediaWikiImporter implements WikiImporter {
 
 			_wikiPageLocalService.updatePage(
 				authorUserId, node.getNodeId(), title, page.getVersion(),
-				content, summary, true, "creole", parentTitle, redirectTitle,
-				serviceContext);
+				content, summary, true,
+				_wikiGroupServiceConfiguration.defaultFormat(), parentTitle,
+				redirectTitle, serviceContext);
 		}
 		catch (Exception e) {
 			throw new PortalException("Error importing page " + title, e);


### PR DESCRIPTION
Hello @zsigmondrab 

This prevents the conversion to creole when importing a wiki page, if the default format is not creole.
The time being, I could not find a way to set the default format to something else besides hardcoding it to the portal code and recompile the wiki module

In WikiGroupServiceConfiguration

```
	/**
	 * Set the default wiki format.
	 */
	@Meta.AD(deflt = "creole", required = false)
	public String defaultFormat();
```

set deflt from "creole" to "mediawiki" and recompile the wiki module.

Also, on master, images are not being loaded in mediawiki pages, but this is not an importing related issue.
 
Best regards,
István
