### PR TITLE
LPS-60792 When dataImport is false(propagated portletpreference from …

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
@@ -41,6 +41,7 @@ import com.liferay.portal.util.PortalUtil;
 import com.liferay.portlet.exportimport.lar.PortletDataContext;
 import com.liferay.portlet.exportimport.lar.PortletDataException;
 import com.liferay.portlet.exportimport.lar.StagedModelDataHandlerUtil;
+import com.liferay.portlet.exportimport.staging.MergeLayoutPrototypesThreadLocal;
 
 import java.util.List;
 import java.util.Map;
@@ -199,6 +200,12 @@ public class JournalContentExportImportPortletPreferencesProcessor
 
 		long importGroupId = GetterUtil.getLong(
 			portletPreferences.getValue("groupId", null));
+
+		if ((importGroupId == portletDataContext.getCompanyGroupId()) &&
+			MergeLayoutPrototypesThreadLocal.isInProgress()) {
+
+			portletDataContext.setScopeType("company");
+		}
 
 		long groupId = MapUtil.getLong(groupIds, importGroupId, importGroupId);
 


### PR DESCRIPTION
Hi Zsigmond,

The pull request extends from https://github.com/daledotshan/liferay-portal/pull/348

I don't confirm whether I understand your meaning right regarding " the context not carry that info originally". I want to explain portletDataContext carry right value because the web content display portlet didn't set global scope. and it only displayed global content.

Thanks,
Hai