### PR TITLE
[Technical Support] LPS-60636 Judge if we need redicrect from i18n path as it is containshe original i18nLanguageId from the request URI.

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/FriendlyURLServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/FriendlyURLServlet.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -346,23 +347,7 @@ public class FriendlyURLServlet extends HttpServlet {
 						layoutFriendlyURLCompositeFriendlyURL.substring(0, pos);
 				}
 
-				boolean i18nRedirect = false;
-
-				String i18nLanguageCode = (String)request.getAttribute(
-					WebKeys.I18N_LANGUAGE_CODE);
-
-				if (Validator.isNotNull(i18nLanguageCode)) {
-					Locale i18nLocale = LanguageUtil.getLocale(
-						group.getGroupId(), i18nLanguageCode);
-
-					if (!LanguageUtil.isAvailableLocale(
-							group.getGroupId(), i18nLocale)) {
-
-						i18nRedirect = true;
-					}
-				}
-
-				if (i18nRedirect ||
+				if (isI18nRedirect(request, group.getGroupId()) ||
 					!StringUtil.equalsIgnoreCase(
 						layoutFriendlyURLCompositeFriendlyURL,
 						layout.getFriendlyURL(locale))) {
@@ -399,6 +384,26 @@ public class FriendlyURLServlet extends HttpServlet {
 			requestContext);
 
 		return new Object[] {actualURL, Boolean.FALSE};
+	}
+
+	protected boolean isI18nRedirect(HttpServletRequest request, long groupId) {
+		String i18nPath = (String)request.getAttribute(WebKeys.I18N_PATH);
+
+		if (Validator.isNull(i18nPath)) {
+			return false;
+		}
+
+		int pos = i18nPath.indexOf(StringPool.SLASH);
+
+		String i18nLanguageId = i18nPath.substring(pos + 1);
+
+		Locale i18nLocale = LanguageUtil.getLocale(i18nLanguageId);
+
+		if (LanguageUtil.isAvailableLocale(groupId, i18nLocale)) {
+			return false;
+		}
+
+		return true;
 	}
 
 	protected Locale setAlternativeLayoutFriendlyURL(


### PR DESCRIPTION
Hey Zsigmond

I have to say LPS-60636 has become my nightmare.

I have no choice but facing whatevers problems I left and keeping fixing them.

Two issues in general.

First of all, I said LanguageUtil is considering locales in company level here: https://github.com/zsigmondrab/liferay-portal/pull/127

But I was stupid that I passed a ``groupId`` to the method. And it became group level.

The correct logic is that

1)  get the i18nLanguageId which i18npath represented(in request URI).
```
String i18nPath = (String)request.getAttribute(WebKeys.I18N_PATH);

int pos = i18nPath.indexOf(StringPool.SLASH);

String i18nLanguageId = i18nPath.substring(pos + 1);
```

2)  get locales form i18nLanguageId in ``locales.enable`` (company level, no group id)
``Locale i18nLocale = LanguageUtil.getLocale(i18nLanguageId);``

3)  Then check if it is group available (``null`` if it is not in ``locales.enable``)
``!LanguageUtil.isAvailableLocale(groupId, i18nLocale)``

The second problem is that we should not use ``i18nlanguageId`` or ``i18nlanguageCode``, as you can see in i18nServlet.java, we have some logic to re-assign these two values.

Only ``i18nPath``  is keeping as original.( We do fix this in https://issues.liferay.com/browse/LPS-60313, we should be aware of not making the same problem any more. ``i18nPath`` should never be re-assigned in i18nServlet).

At last, could I ask you help testing this pr( I asked the cse for help as well), to see if we still encounter redirection loop or the redirection happens as expected?

I am not that confident any more.

Sorry
John.