### PR TITLE
LPS-73828 Allow the default language to be empty in Localized text field

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -276,7 +276,7 @@ AUI.add(
 
 						inputLanguage.val(value);
 
-						if (instance._fillDefaultLanguage) {
+						if (instance._fillDefaultLanguage && selectedLanguageId === defaultInputLanguage) {
 							defaultInputLanguage.val(value);
 						}
 


### PR DESCRIPTION
Do not save the text from the input to the defaultvalue unless the selected language is the default one